### PR TITLE
Allow models to decide whether index update is needed.

### DIFF
--- a/trampoline/apps.py
+++ b/trampoline/apps.py
@@ -42,7 +42,7 @@ def recursive_update(d, u):
 
 
 def post_save_es_index(sender, instance, **kwargs):
-    if instance.is_indexable():
+    if instance.is_indexable() and instance.is_index_update_needed():
         try:
             # post_save fires after the save occurs but before the transaction
             # is commited.

--- a/trampoline/mixins.py
+++ b/trampoline/mixins.py
@@ -28,7 +28,7 @@ class ESIndexableMixin(object):
         return True
 
     def is_index_update_needed(self):
-        """ Allow models to decide whether to update index from post_save signal or not. """
+        """ Allow models to decide whether to update index from post_save """
         return True
 
     def get_es_doc_mapping(self):

--- a/trampoline/mixins.py
+++ b/trampoline/mixins.py
@@ -27,6 +27,10 @@ class ESIndexableMixin(object):
     def is_indexable(self):
         return True
 
+    def is_index_update_needed(self):
+        """ Allow models to decide whether to update index from post_save signal or not. """
+        return True
+
     def get_es_doc_mapping(self):
         raise NotImplementedError
 


### PR DESCRIPTION
This controls only the trigger from post_save signal. Some models may implement this method and decide if index update is needed based on changed fields. 
`is_indexable` method cannot be used for the above use case because it's also used in management commands, and I only need to control update from post_save signal.

`is_index_update_needed` returns True by default, same as `is_indexable`.
