### PR TITLE
Support for multiple connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,21 @@ Add `trampoline` to your `INSTALLED_APPS`.
 Define the setting:
 ```python
 TRAMPOLINE = {
-  'HOST': 'localhost',
-  'INDICES': {
-    'index_name': {
-      'models': (
-        'app_name.models.ModelName',
-      ),
-    }
-  },
-  'OPTIONS': {
-    'fail_silently': True,
-    'disabled': False,
-  },
+    'CONNECTIONS': {
+        'default': {'hosts': 'localhost:9200'},
+        # 'another_conn': {'hosts': 'localhost:9201'},
+    },
+    'INDICES': {
+        'index_name': {
+            'models': (
+                'app_name.models.ModelName',
+            ),
+        }
+    },
+    'OPTIONS': {
+        'fail_silently': True,
+        'disabled': False,
+    },
 }
 ```
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -28,6 +28,9 @@ class TestMixins(BaseTestCase):
     def test_is_indexable(self):
         self.assertTrue(ESIndexableMixin().is_indexable())
 
+    def test_is_index_update_needed(self):
+        self.assertTrue(ESIndexableMixin().is_index_update_needed())
+
     def test_get_indexable_queryset(self):
         self.assertEqual(
             str(Token.get_indexable_queryset().query),

--- a/trampoline/apps.py
+++ b/trampoline/apps.py
@@ -42,7 +42,7 @@ def recursive_update(d, u):
 
 
 def post_save_es_index(sender, instance, **kwargs):
-    if instance.is_indexable():
+    if instance.is_indexable() and instance.is_index_update_needed():
         try:
             # post_save fires after the save occurs but before the transaction
             # is commited.

--- a/trampoline/apps.py
+++ b/trampoline/apps.py
@@ -21,7 +21,9 @@ except ImportError:
 
 
 DEFAULT_TRAMPOLINE = {
-    'HOST': 'localhost',
+    'CONNECTIONS': {
+        'default': {'hosts': 'localhost'},
+    },
     'INDICES': {},
     'OPTIONS': {
         'fail_silently': True,
@@ -90,7 +92,13 @@ class TrampolineConfig(AppConfig):
         super(TrampolineConfig, self).__init__(*args, **kwargs)
 
     def ready(self):
-        connections.configure(default={'hosts': self.host})
+        if 'HOST' in self.settings:
+            raise NotImplementedError('"HOST" key replaced by "CONNECTIONS"')
+        options = {}
+        for alias, details in self.settings['CONNECTIONS'].items():
+            options[alias] = details
+
+        connections.configure(**options)
 
     def get_index_models(self, index_name):
         try:
@@ -122,9 +130,11 @@ class TrampolineConfig(AppConfig):
         TRAMPOLINE = deepcopy(DEFAULT_TRAMPOLINE)
         return recursive_update(TRAMPOLINE, USER_TRAMPOLINE)
 
-    @property
-    def connection(self):
-        return connections.get_connection()
+    def get_connection(self, alias='default'):
+        if not alias:
+            alias = 'default'
+        return connections.get_connection(alias)
+    connection = property(get_connection)
 
     @property
     def host(self):

--- a/trampoline/management/base.py
+++ b/trampoline/management/base.py
@@ -31,6 +31,13 @@ class ESBaseCommand(BaseCommand):
             default=None,
             help="Name of the target index."
         ),
+        'using': make_option(
+            '--using',
+            '-u',
+            dest='using',
+            default='default',
+            help="Connection name."
+        ),
     }
 
     option_list = BaseCommand.option_list + (

--- a/trampoline/management/commands/es_create_alias.py
+++ b/trampoline/management/commands/es_create_alias.py
@@ -18,7 +18,7 @@ class Command(ESBaseCommand):
 
     def run(self, *args, **options):
         using = self.using
-        
+
         if not self.dry_run:
             self.trampoline_config.get_connection(using).indices.put_alias(
                 index=self.target_name,

--- a/trampoline/management/commands/es_create_alias.py
+++ b/trampoline/management/commands/es_create_alias.py
@@ -11,13 +11,15 @@ class Command(ESBaseCommand):
 
     option_list = ESBaseCommand.option_list + (
         ESBaseCommand.options['index_name'],
-        ESBaseCommand.options['target_name']
+        ESBaseCommand.options['target_name'],
+        ESBaseCommand.options['using']
     )
     required_options = ('index_name', 'target_name')
 
     def run(self, *args, **options):
+
         if not self.dry_run:
-            self.trampoline_config.connection.indices.put_alias(
+            self.trampoline_config.get_connection(self.using).indices.put_alias(
                 index=self.target_name,
                 name=self.index_name
             )

--- a/trampoline/management/commands/es_create_alias.py
+++ b/trampoline/management/commands/es_create_alias.py
@@ -17,9 +17,10 @@ class Command(ESBaseCommand):
     required_options = ('index_name', 'target_name')
 
     def run(self, *args, **options):
-
+        using = self.using
+        
         if not self.dry_run:
-            self.trampoline_config.get_connection(self.using).indices.put_alias(
+            self.trampoline_config.get_connection(using).indices.put_alias(
                 index=self.target_name,
                 name=self.index_name
             )

--- a/trampoline/management/commands/es_delete_alias.py
+++ b/trampoline/management/commands/es_delete_alias.py
@@ -11,7 +11,8 @@ class Command(ESBaseCommand):
 
     option_list = ESBaseCommand.option_list + (
         ESBaseCommand.options['index_name'],
-        ESBaseCommand.options['target_name']
+        ESBaseCommand.options['target_name'],
+        ESBaseCommand.options['using']
     )
     required_options = ('index_name', 'target_name')
 
@@ -21,7 +22,7 @@ class Command(ESBaseCommand):
             .format(self.index_name)
         )
         if not self.dry_run:
-            self.trampoline_config.connection.indices.delete_alias(
+            self.trampoline_config.get_connection(self.using).indices.delete_alias(
                 index=self.target_name,
                 name=self.index_name
             )

--- a/trampoline/management/commands/es_delete_alias.py
+++ b/trampoline/management/commands/es_delete_alias.py
@@ -21,8 +21,10 @@ class Command(ESBaseCommand):
             u"Are you really sure you want to delete the alias '{0}' ?"
             .format(self.index_name)
         )
+        using = self.using
+
         if not self.dry_run:
-            self.trampoline_config.get_connection(self.using).indices.delete_alias(
+            self.trampoline_config.get_connection(using).indices.delete_alias(
                 index=self.target_name,
                 name=self.index_name
             )

--- a/trampoline/mixins.py
+++ b/trampoline/mixins.py
@@ -28,7 +28,7 @@ class ESIndexableMixin(object):
         return True
 
     def is_index_update_needed(self):
-        """ Allow models to decide whether to update index from post_save signal or not. """
+        """ Allow models to decide whether to update index from post_save """
         return True
 
     def get_es_doc_mapping(self):

--- a/trampoline/mixins.py
+++ b/trampoline/mixins.py
@@ -27,6 +27,10 @@ class ESIndexableMixin(object):
     def is_indexable(self):
         return True
 
+    def is_index_update_needed(self):
+        """ Allow models to decide whether to update index from post_save signal or not. """
+        return True
+
     def get_es_doc_mapping(self):
         raise NotImplementedError
 

--- a/trampoline/mixins.py
+++ b/trampoline/mixins.py
@@ -69,8 +69,9 @@ class ESIndexableMixin(object):
         doc_type = self.get_es_doc_type()
         doc_type_name = doc_type._doc_type.name
         index_name = index_name or doc_type._doc_type.index
+        using = doc_type._doc_type.using
 
         if async:
-            es_delete_doc.delay(index_name, doc_type_name, self.pk)
+            es_delete_doc.delay(index_name, doc_type_name, self.pk, using)
         else:
-            es_delete_doc.apply((index_name, doc_type_name, self.pk))
+            es_delete_doc.apply((index_name, doc_type_name, self.pk, using))

--- a/trampoline/tasks.py
+++ b/trampoline/tasks.py
@@ -22,7 +22,7 @@ def es_index_object(index_name, content_type_id, object_id):
 
     try:
         content_type = ContentType.objects.get_for_id(content_type_id)
-        # I've used this method because django has some issues with CT and database routers
+        # django has some issues with CT and database routers, use model_class
         obj = content_type.model_class()._default_manager.get(pk=object_id)
         doc = obj.get_es_doc_mapping()
         doc.meta.id = obj.pk


### PR DESCRIPTION
Refactored connections. 
Now we can use multiple connections (and pass any other option to elasticsearch_dsl connection). 
I took advantage of automatic connection routing from elasticsearch_dsl connection aliases and "using" property from DocTypes. It's best practice to use their own connection router.

To use a different connection, simply add it to settings

``` python
TRAMPOLINE = {
    'CONNECTIONS': {
        'default': {'hosts': 'localhost:9200'},
        'another_conn': {'hosts': 'localhost:9201'},
    },
    'INDICES': {
...
```

and "using" meta property

``` python
class MyDoc(elasticsearch_dsl.DocType):
    class Meta:
        index = 'my_index'
        using = 'another_conn'
```

Also, added a new method on mixin named "is_index_update_needed". This is ran only in post_save signal and allows models to decide if index update is needed (some models may implement this because they keep track of changed fields, and update indexes only if necessary).

@laurentguilbert  With this pull request, I am able to use django-trampoline in production 😄

Kind regards
