### PR TITLE
es_rebuild_index command

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -37,7 +37,7 @@ class Person(ESIndexableMixin, models.Model):
     last_name = models.CharField(max_length=200)
 
     def __unicode__(self):
-        return self.name
+        return self.first_name
 
     es_doc_type = PersonDoc
     es_auto_doc_type_mapping = True

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -261,11 +261,11 @@ class TestCommands(BaseTestCase):
         index.create()
         self.refresh()
 
-        Token.objects.bulk_create(
+        Token.objects.bulk_create([
             Token.objects.create(name="token1"),
             Token.objects.create(name="token2"),
             Token.objects.create(name="token3"),
-        )
+        ])
 
         # Dry run.
         call_command(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -261,9 +261,11 @@ class TestCommands(BaseTestCase):
         index.create()
         self.refresh()
 
-        token1 = Token.objects.create(name="token1")
-        token2 = Token.objects.create(name="token2")
-        token3 = Token.objects.create(name="token2")
+        Token.objects.bulk_create(
+            Token.objects.create(name="token1"),
+            Token.objects.create(name="token2"),
+            Token.objects.create(name="token3"),
+        )
 
         # Dry run.
         call_command(
@@ -271,17 +273,13 @@ class TestCommands(BaseTestCase):
             index_name='foobar',
             dry_run=True
         )
-        self.assertDocDoesntExist(token1)
-        self.assertDocDoesntExist(token2)
-        self.assertDocDoesntExist(token3)
+        self.assertEqual(Token.get_es_doc_type().search().count(), 0)
 
         call_command(
             'es_rebuild_index',
             index_name='foobar',
         )
-        self.assertDocExists(token1)
-        self.assertDocExists(token2)
-        self.assertDocExists(token3)
+        self.assertEqual(Token.get_es_doc_type().search().count(), 3)
 
         Token.objects.all().delete()
         call_command(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -283,11 +283,9 @@ class TestCommands(BaseTestCase):
         self.assertDocExists(token2)
         self.assertDocExists(token3)
 
-        Token.objects.filter(name='token1').delete()
-        # now we have an object in ES that's missing from db
-        # rebuild should delete it from ES
+        Token.objects.all().delete()
         call_command(
             'es_rebuild_index',
             index_name='foobar',
         )
-        self.assertDocDoesntExist(token1)
+        self.assertEqual(Token.get_es_doc_type().search().count(), 0)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -262,9 +262,9 @@ class TestCommands(BaseTestCase):
         self.refresh()
 
         Token.objects.bulk_create([
-            Token.objects.create(name="token1"),
-            Token.objects.create(name="token2"),
-            Token.objects.create(name="token3"),
+            Token(name="token1"),
+            Token(name="token2"),
+            Token(name="token3"),
         ])
 
         # Dry run.

--- a/trampoline/management/base.py
+++ b/trampoline/management/base.py
@@ -145,7 +145,7 @@ class ESBaseCommand(BaseCommand):
         return ProgressBar(loop_length)
 
 
-class ProgressBar:  # pragma: no cover
+class ProgressBar:
     """ Taken from random gist, can't recall which """
     def __init__(self, loop_length):
         import time
@@ -162,7 +162,7 @@ class ProgressBar:  # pragma: no cover
             self.curr_pct = int(self.curr_count)
             if self.curr_pct <= 100:
                 print(self.curr_pct, end=' ')
-            elif not self.overflow:
+            elif not self.overflow:  # pragma: no cover
                 self.overflow = True
 
     def finish(self):
@@ -170,9 +170,9 @@ class ProgressBar:  # pragma: no cover
             print("100", end=' ')
             elapsed = time.time() - self.start
             print('\nElapsed time: {:0.1f} seconds.\n'.format(elapsed))
-        elif self.overflow:
+        elif self.overflow:  # pragma: no cover
             print('Elapsed time after end of loop: '
                   '{:0.1f} seconds.\n'.format(time.time() - self.start))
-        else:
+        else:  # pragma: no cover
             print('\n* End of loop reached earlier than expected.\nElapsed '
                   'time: {:0.1f} seconds.\n'.format(time.time() - self.start))

--- a/trampoline/management/base.py
+++ b/trampoline/management/base.py
@@ -10,7 +10,6 @@ import traceback
 from tqdm import tqdm
 
 import six
-import time
 
 from django.core.management.base import BaseCommand
 

--- a/trampoline/management/base.py
+++ b/trampoline/management/base.py
@@ -166,39 +166,3 @@ class ESBaseCommand(BaseCommand):
 
     def print_warning(self, message):  # pragma: no cover
         print(u"{0}{1}{2}".format(self.YELLOW, message, self.RESET))
-
-    def init_progressbar(self, loop_length):
-        return ProgressBar(loop_length)
-
-
-class ProgressBar:
-    """ Taken from random gist, can't recall which """
-    def __init__(self, loop_length):
-        import time
-        self.start = time.time()
-        self.increment_size = 100.0 / loop_length
-        self.curr_count = 0
-        self.curr_pct = 0
-        self.overflow = False
-        print('% complete: ', end='')
-
-    def increment(self):
-        self.curr_count += self.increment_size
-        if int(self.curr_count) > self.curr_pct:
-            self.curr_pct = int(self.curr_count)
-            if self.curr_pct <= 100:
-                print(self.curr_pct, end=' ')
-            elif not self.overflow:  # pragma: no cover
-                self.overflow = True
-
-    def finish(self):
-        if 99 <= self.curr_pct <= 100:
-            print("100", end=' ')
-            elapsed = time.time() - self.start
-            print('\nElapsed time: {:0.1f} seconds.\n'.format(elapsed))
-        elif self.overflow:  # pragma: no cover
-            print('Elapsed time after end of loop: '
-                  '{:0.1f} seconds.\n'.format(time.time() - self.start))
-        else:  # pragma: no cover
-            print('\n* End of loop reached earlier than expected.\nElapsed '
-                  'time: {:0.1f} seconds.\n'.format(time.time() - self.start))

--- a/trampoline/management/base.py
+++ b/trampoline/management/base.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 
 import six
+import time
 
 from django.core.management.base import BaseCommand
 
@@ -37,6 +38,13 @@ class ESBaseCommand(BaseCommand):
             dest='using',
             default='default',
             help="Connection name."
+        ),
+        'async': make_option(
+            '--async',
+            dest='async',
+            action='store_true',
+            default=False,
+            help="Async indexing."
         ),
     }
 
@@ -132,3 +140,39 @@ class ESBaseCommand(BaseCommand):
 
     def print_warning(self, message):  # pragma: no cover
         print(u"{0}{1}{2}".format(self.YELLOW, message, self.RESET))
+
+    def init_progressbar(self, loop_length):
+        return ProgressBar(loop_length)
+
+
+class ProgressBar:  # pragma: no cover
+    """ Taken from random gist, can't recall which """
+    def __init__(self, loop_length):
+        import time
+        self.start = time.time()
+        self.increment_size = 100.0 / loop_length
+        self.curr_count = 0
+        self.curr_pct = 0
+        self.overflow = False
+        print('% complete: ', end='')
+
+    def increment(self):
+        self.curr_count += self.increment_size
+        if int(self.curr_count) > self.curr_pct:
+            self.curr_pct = int(self.curr_count)
+            if self.curr_pct <= 100:
+                print(self.curr_pct, end=' ')
+            elif not self.overflow:
+                self.overflow = True
+
+    def finish(self):
+        if 99 <= self.curr_pct <= 100:
+            print("100", end=' ')
+            elapsed = time.time() - self.start
+            print('\nElapsed time: {:0.1f} seconds.\n'.format(elapsed))
+        elif self.overflow:
+            print('Elapsed time after end of loop: '
+                  '{:0.1f} seconds.\n'.format(time.time() - self.start))
+        else:
+            print('\n* End of loop reached earlier than expected.\nElapsed '
+                  'time: {:0.1f} seconds.\n'.format(time.time() - self.start))

--- a/trampoline/management/commands/es_rebuild_index.py
+++ b/trampoline/management/commands/es_rebuild_index.py
@@ -63,26 +63,27 @@ class Command(ESBaseCommand):
                 if bad_ids:
                     self.print_info(u"Deleting {0} items".format(len(bad_ids)))
                     for es_id in bad_ids:
-                        model.es_doc_type.get(es_id).delete()
+                        model.es_doc_type.get(es_id).delete(ignore=404)
 
                 ct_id = ContentType.objects.get_for_model(model).pk
 
                 self.print_info(u"Reindexing {0} items".format(len(db_pks)))
 
-                pbar = self.init_progressbar(len(db_pks))
+                if db_pks:
+                    pbar = self.init_progressbar(len(db_pks))
 
-                for pk in db_pks:
-                    if options['async']:
-                        es_index_object.apply_async(
-                            args=(self.target_name, ct_id, pk),
-                            queue=self.trampoline_config.celery_queue)
-                    else:
-                        es_index_object.apply(
-                            args=(self.target_name, ct_id, pk))
-                    pbar.increment()
-                    sys.stdout.flush()
+                    for pk in db_pks:
+                        if options['async']:
+                            es_index_object.apply_async(
+                                args=(self.target_name, ct_id, pk),
+                                queue=self.trampoline_config.celery_queue)
+                        else:
+                            es_index_object.apply(
+                                args=(self.target_name, ct_id, pk))
+                        pbar.increment()
+                        sys.stdout.flush()
 
-                pbar.finish()
+                    pbar.finish()
             else:
                 self.print_info('ES Items to delete: {}'.format(len(bad_ids)))
                 self.print_info('Records to reindex: {}'.format(len(db_pks)))

--- a/trampoline/management/commands/es_rebuild_index.py
+++ b/trampoline/management/commands/es_rebuild_index.py
@@ -84,8 +84,7 @@ class Command(ESBaseCommand):
                         sys.stdout.flush()
 
                     pbar.finish()
+                    self.print_success("Indexation completed.")
             else:
                 self.print_info('ES Items to delete: {}'.format(len(bad_ids)))
                 self.print_info('Records to reindex: {}'.format(len(db_pks)))
-
-        self.print_success("Indexation completed.")

--- a/trampoline/management/commands/es_rebuild_index.py
+++ b/trampoline/management/commands/es_rebuild_index.py
@@ -1,0 +1,85 @@
+"""
+Management command for trampoline.
+"""
+import logging
+import sys
+
+from django.contrib.contenttypes.models import ContentType
+from elasticsearch_dsl import Index
+
+from trampoline.management.base import ESBaseCommand
+from trampoline.tasks import es_index_object
+
+logger = logging.getLogger(__name__)
+
+
+class Command(ESBaseCommand):
+    help = (
+        "Rebuilds index {0}{1}INDEX_NAME{2} based on the method "
+        "{0}get_indexable_queryset{2} on the related models. "
+        "Compares ids fro ES and queryset"
+    ).format(ESBaseCommand.BOLD, ESBaseCommand.UNDERLINE, ESBaseCommand.RESET)
+
+    option_list = ESBaseCommand.option_list + (
+        ESBaseCommand.options['index_name'],
+        ESBaseCommand.options['target_name'],
+        ESBaseCommand.options['async'],
+    )
+    required_options = ('index_name',)
+
+    STATUS_INDEXED = 0
+    STATUS_SKIPPED = 1
+    STATUS_FAILED = 2
+
+    def run(self, *args, **options):
+        self.target_name = self.target_name or self.index_name
+
+        index = Index(self.target_name)
+        if not index.exists():
+            self.print_error(
+                u"Index '{0}' does not exist."
+                .format(self.target_name)
+            )
+            sys.exit(1)
+
+        self.print_info(u"Indexing objects on '{0}'.".format(self.target_name))
+
+        models = self.trampoline_config.get_index_models(self.index_name)
+
+        for model in models:
+            self.print_info(u"Processing model: '{0}'.".format(model.__name__))
+            queryset = model.get_indexable_queryset()
+
+            db_pks = set([int(pk) for pk in queryset.values_list('pk',
+                                                                 flat=True)])
+            es_ids = []
+            for item in model.es_doc_type.search().fields([]).scan():
+                es_ids.append(int(item.meta.id))
+            es_ids = set(es_ids)
+
+            bad_ids = es_ids - db_pks
+
+            if bad_ids:
+                self.print_info(u"Deleting {0} items".format(len(bad_ids)))
+                for es_id in bad_ids:
+                    model.es_doc_type.get(es_id).delete()
+
+            ct_id = ContentType.objects.get_for_model(model).pk
+
+            self.print_info(u"Reindexing {0} items".format(len(db_pks)))
+
+            pbar = self.init_progressbar(len(db_pks))
+
+            for pk in db_pks:
+                if options['async']:
+                    es_index_object.apply_async(
+                        args=(self.target_name, ct_id, pk),
+                        queue=self.trampoline_config.celery_queue)
+                else:
+                    es_index_object.apply(args=(self.target_name, ct_id, pk))
+                pbar.increment()
+                sys.stdout.flush()
+
+            pbar.finish()
+
+        self.print_success("Indexation completed.")

--- a/trampoline/tasks.py
+++ b/trampoline/tasks.py
@@ -23,6 +23,9 @@ def es_index_object(index_name, content_type_id, object_id):
     try:
         content_type = ContentType.objects.get_for_id(content_type_id)
         obj = content_type.model_class()._default_manager.get(pk=object_id)
+        if not obj.is_indexable():
+            return
+
         doc = obj.get_es_doc_mapping()
         doc.meta.id = obj.pk
         doc.save(index=index_name)

--- a/trampoline/tasks.py
+++ b/trampoline/tasks.py
@@ -23,9 +23,6 @@ def es_index_object(index_name, content_type_id, object_id):
     try:
         content_type = ContentType.objects.get_for_id(content_type_id)
         obj = content_type.model_class()._default_manager.get(pk=object_id)
-        if not obj.is_indexable():
-            return
-
         doc = obj.get_es_doc_mapping()
         doc.meta.id = obj.pk
         doc.save(index=index_name)


### PR DESCRIPTION
Implemented `es_rebuild_index` command, which compares data from ES with queryset and does the required operations (update/delete). 
The interesting part of this command is that it works with very high volumes of data. When you have a dozen of millions of record in database, you cannot use "queryset.all()" :)

I know it doesn't really follow the design pattern of the other commands (dry run, result), but that's how i needed it to be implemented (using pks, not objects). 
Sadly I haven't had time to implement tests, nor update the readme. If you could help me with that, it would be great.

There's also a dead simple progress bar, maybe you want to use it on other commands too.

Kind regards,

ps: coverage would most likely not be 100% anymore
